### PR TITLE
Improper naming convention, lead to down site.

### DIFF
--- a/source/assets/scripts/main.js
+++ b/source/assets/scripts/main.js
@@ -6,7 +6,7 @@ const apiKey = "52121edf0f71442dbf23b640dbe1ad78" ;
 const searchBar = document.getElementById("homepage-search-bar");
 const search = document.getElementById("homepage-search-btn");
 const MAX_NUM_RECIPE_CARDS = 30;
-const searchFilter = document.querySelector(".searchFilter");
+const searchFilter = document.querySelector(".search-filter");
 let searchQuery = "";
 let baseURL = "";
 


### PR DESCRIPTION
__What Was Done?__
In my code review, I didn't notice that the naming convention was wrong for one of the query selectors. Changed to correct name, website works as expected.