### PR TITLE
filter not show in mobile

### DIFF
--- a/source/assets/scripts/binds/bindRecipeCard.js
+++ b/source/assets/scripts/binds/bindRecipeCard.js
@@ -36,8 +36,10 @@ import {
     );
     recipeViewersWrapper.classList.remove("shown");
 
-    // Display the search filter
-    searchFilter.classList.add("shown");
+    // Display the search filter, not if mobile
+    if(window.screen.width > 800){
+      searchFilter.classList.add("shown");
+    } 
 
     //Display the filter toggle class
     filterToggle.classList.add("shown");


### PR DESCRIPTION
When you go to search page in mobile the search filters are closed by default